### PR TITLE
Tag generation

### DIFF
--- a/demoapps/helloWashington/helloWashington.c
+++ b/demoapps/helloWashington/helloWashington.c
@@ -1,0 +1,47 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define KEYFILE_LEN 16
+
+int check_license_key(void) {
+    FILE *fp;
+    uint8_t key[KEYFILE_LEN];
+    int i;
+    uint32_t tmp = 0;
+
+    fp = fopen("/etc/hellowashington/license.key", "rb");
+
+    if(!fp) {
+        return -1;
+    }
+
+    if(fread(key, 1, KEYFILE_LEN, fp) != KEYFILE_LEN) {
+        return -2;
+    }
+
+    fclose(fp);
+
+    for(i = 0; i < KEYFILE_LEN; ++i) {
+        tmp += key[i];
+    }
+
+    if((tmp % 3) == 0 && (tmp % 7) == 0) {
+        return 0;
+    }
+
+    return -3;
+}
+
+int main(int argc, char *argv[]) {
+    printf("Hello, Washington starting up....\n");
+
+    if(check_license_key()) {
+        fprintf(stderr, "No valid license key found, exiting.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Verified license key as authentic.\n");
+    printf("Welcome to the 'Hello, Washington' BloSS@M demo program.\n");
+    return 0;
+}

--- a/demoapps/helloWashington/key/helloWashingtonKey.c
+++ b/demoapps/helloWashington/key/helloWashingtonKey.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
+
+#define KEYFILE_LEN 16
+
+int check_license_key(const uint8_t key[KEYFILE_LEN]) {
+    int i;
+    uint32_t tmp = 0;
+
+    for(i = 0; i < KEYFILE_LEN; ++i) {
+        tmp += key[i];
+    }
+
+    if((tmp % 3) == 0 && (tmp % 7) == 0) {
+        return 0;
+    }
+
+    return -3;
+}
+
+int main(int argc, char *argv[]) {
+    uint8_t key[KEYFILE_LEN] = { 0 };
+    int i;
+    FILE *fp;
+
+    if(argc != 2) {
+        exit(EXIT_FAILURE);
+    }
+
+    printf("Generating keyfile\n");
+    srand(time(NULL));
+
+    do {
+        printf("Working....\n");
+
+        for(i = 0; i < KEYFILE_LEN; ++i) {
+            key[i] = (uint8_t)rand();
+            printf("%d ", key[i]);
+        }
+        printf("\n");
+    } while(check_license_key(key));
+
+    fp = fopen(argv[1], "wb");
+    if(!fp) {
+        exit(EXIT_FAILURE);
+    }
+
+    fwrite(key, 1, KEYFILE_LEN, fp);
+    fclose(fp);
+
+    printf("Key written to %s\n", argv[1]);
+
+    return 0;
+}

--- a/tag_generator/LICENSE.txt
+++ b/tag_generator/LICENSE.txt
@@ -1,0 +1,23 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Christian Fässler, Danilo Bargen, Jonas Furrer.
+Copyright (c) 2017 Davide De Giorgio, Christof Greiner.
+Copyright (c) 2017 Andreas Steffen.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tag_generator/README.txt
+++ b/tag_generator/README.txt
@@ -1,0 +1,20 @@
+The following files are modified from https://github.com/strongswan/swidGenerator, which is licensed under the MIT License. This is described under tag_generator/LICENSE.txt
+
+- tag_generator/command_manager.py
+- tag_generator/content_creator.py
+- tag_generator/exceptions.py
+- tag_generator/generators/init.py
+- tag_generator/generators/content_creator.py
+- tag_generator/generators/softwareid_generator.py
+- tag_generator/generators/swid_generator.py
+- tag_generator/generators/utils.py
+- tag_generator/package_info.py
+- tag_generator/patches.py
+- tag_generator/signature_template.py
+- tag_generator/utils.py
+- tag_generator/LICENSE.txt
+
+The following files are original to the blossom-sam project:
+
+- tag_generator/main.py
+- tag_generator/yaml_parse.py

--- a/tag_generator/command_manager.py
+++ b/tag_generator/command_manager.py
@@ -1,0 +1,64 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+
+import os
+import subprocess
+from exceptions import CommandManagerError
+from patches import py26_check_output
+
+
+# Python 2.6 compatibility
+if 'check_output' not in dir(subprocess):
+    # Ugly monkey patching hack ahead
+    subprocess.check_output = py26_check_output
+
+
+class CommandManager(object):
+
+    @staticmethod
+    def run_command(command_argumentlist, working_directory=os.getcwd()):
+        """
+        Executes a command. No output expected.
+        :param command_argumentlist: Command-Arguments
+        :param working_directory: The working directory of the command.
+        """
+        with open(os.devnull, 'w') as devnull:
+            try:
+                subprocess.call(command_argumentlist, stderr=devnull, cwd=working_directory)
+            except BaseException as e:
+                raise CommandManagerError(e)
+
+    @staticmethod
+    def run_command_check_output(command_argumentlist, stdin=None, working_directory=os.getcwd()):
+        """
+        Exectues a command. Output expected.
+        :param command_argumentlist: Command-Arguments
+        :param stdin: standard-input of the subprocess (e.x stdout from ohter subprocess)
+        :param working_directory: Working directory of the command.
+        :return: Console-Output of the command.
+        """
+        try:
+            if stdin is None:
+                output = subprocess.check_output(command_argumentlist, cwd=working_directory)
+                if isinstance(output, bytes):
+                    output = output.decode('utf-8')
+                return output
+            else:
+                subprocess.check_output(command_argumentlist, stdin=stdin, cwd=working_directory)
+        except BaseException as e:
+            raise CommandManagerError(e)
+
+    @staticmethod
+    def run_command_popen(command_argumentlist, stdout=None):
+        """
+        Runs a command with subprocess Library.
+        :param command_argumentlist: Command arguments
+        :param stdout: Standard output (e.x subprocess.PIPE)
+        :return: Popen object to catch pipeline output
+        """
+        try:
+            if stdout is not None:
+                return subprocess.Popen(command_argumentlist, stdout=stdout)
+            else:
+                return subprocess.Popen(command_argumentlist)
+        except BaseException as e:
+            raise CommandManagerError(e)

--- a/tag_generator/content_creator.py
+++ b/tag_generator/content_creator.py
@@ -1,0 +1,122 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import os.path
+import ntpath
+
+from utils import create_sha256_hash, create_sha384_hash, create_sha512_hash
+from itertools import groupby
+from xml.etree import ElementTree as ET
+
+
+def _add_hashes(file_info, file_tag, hash_algorithms):
+    if 'sha256' in hash_algorithms:
+        file_tag.set('SHA256:hash', create_sha256_hash(file_info.actual_full_pathname))
+    if 'sha384' in hash_algorithms:
+        file_tag.set('SHA384:hash', create_sha384_hash(file_info.actual_full_pathname))
+    if 'sha512' in hash_algorithms:
+        file_tag.set('SHA512:hash', create_sha512_hash(file_info.actual_full_pathname))
+
+
+def _sort_files(files):
+    def _lenfunc(obj):
+        return len(obj.full_pathname_splitted)
+
+    def _keyfunc(file, i):
+        return file.full_pathname_splitted[i - 1]
+
+    longest_path_length = len(max(files, key=_lenfunc).full_pathname_splitted) - 1
+
+    for file_info in files:
+        del file_info.full_pathname_splitted[-1]
+
+        path_length = len(file_info.full_pathname_splitted)
+        file_info.full_pathname_splitted.extend([''] * (longest_path_length - path_length))
+
+    for path_length in range(longest_path_length, 0, -1):
+        files.sort(key=lambda f, i=path_length: _keyfunc(f, i))
+    return files
+
+
+def create_flat_content_tag(root_element, package_info, hash_algorithms):
+    last_full_pathname = ""
+    last_directory_tag = ""
+
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
+    if len(package_info.files) > 0:
+        package_info.files = _sort_files(package_info.files)
+
+    for file_info in package_info.files:
+
+        head, file_name = ntpath.split(file_info.full_pathname)
+        root, folder_name = ntpath.split(head)
+        if root == '//':
+            root = '/'
+
+        full_pathname = root + folder_name
+
+        if last_full_pathname == full_pathname:
+            file_tag = ET.SubElement(last_directory_tag, 'File')
+            file_tag.set('name', file_name)
+        else:
+            directory_tag = ET.SubElement(root_element, 'Directory')
+            directory_tag.set('root', root)
+            directory_tag.set('name', folder_name)
+            file_tag = ET.SubElement(directory_tag, 'File')
+            file_tag.set('name', file_name)
+            last_full_pathname = full_pathname
+            last_directory_tag = directory_tag
+
+        if file_info.mutable:
+            file_tag.set('n8060:mutable', "true")
+
+        file_tag.set('size', file_info.size)
+
+        _add_hashes(file_info, file_tag, hash_algorithms)
+
+    return root_element
+
+
+def create_hierarchic_content_tag(root_element, package_info, hash_algorithms):
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
+    def _file_hierarchy(filelist, depth=0, parent_tag=None):
+        def _keyfunc(obj):
+            return obj.full_pathname_splitted[depth]
+
+        filelist.sort(key=_keyfunc)
+
+        for head, tail_of_file_iterator in groupby(filelist, _keyfunc):
+            sub_files = list()
+            for file_info in tail_of_file_iterator:
+                if depth + 1 >= len(file_info.full_pathname_splitted):
+                    file_tag = ET.SubElement(parent_tag, 'File')
+                    file_tag.set('name', file_info.name)
+                    if file_info.mutable:
+                        file_tag.set('n8060:mutable', "true")
+                    file_tag.set('size', file_info.size)
+                    if depth == 0:
+                        if os.path.isabs(file_info.full_pathname):
+                            file_tag.set('root', '/')
+
+                    _add_hashes(file_info, file_tag, hash_algorithms)
+                else:
+                    sub_files.append(file_info)
+
+            if len(sub_files) > 0:
+                sub_tag = ET.SubElement(parent_tag, 'Directory')
+                sub_tag.set('name', head)
+                if depth == 0:
+                    if os.path.isabs(file_info.full_pathname):
+                        sub_tag.set('root', '/')
+                _file_hierarchy(sub_files, depth=depth + 1, parent_tag=sub_tag)
+
+    _file_hierarchy(list(package_info.files), parent_tag=root_element)
+
+    return root_element

--- a/tag_generator/exceptions.py
+++ b/tag_generator/exceptions.py
@@ -1,0 +1,31 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+
+class AutodetectionError(RuntimeError):
+    """
+    Raised when autodetecting the environment fails.
+    """
+    pass
+
+
+class EnvironmentNotInstalledError(RuntimeError):
+    """
+    Raised when a manually specified environment cannot be found on the system.
+    """
+    pass
+
+
+class RequirementsNotInstalledError(RuntimeError):
+    """
+    Raised when the requirements for a operation is not installed.
+    """
+    pass
+
+
+class CommandManagerError(RuntimeError):
+    """
+    Raised when CommandManager cannot run command.
+    """
+    pass

--- a/tag_generator/generators/content_creator.py
+++ b/tag_generator/generators/content_creator.py
@@ -1,0 +1,122 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import os.path
+import ntpath
+
+from .utils import create_sha256_hash, create_sha384_hash, create_sha512_hash
+from itertools import groupby
+from xml.etree import ElementTree as ET
+
+
+def _add_hashes(file_info, file_tag, hash_algorithms):
+    if 'sha256' in hash_algorithms:
+        file_tag.set('SHA256:hash', create_sha256_hash(file_info.actual_full_pathname))
+    if 'sha384' in hash_algorithms:
+        file_tag.set('SHA384:hash', create_sha384_hash(file_info.actual_full_pathname))
+    if 'sha512' in hash_algorithms:
+        file_tag.set('SHA512:hash', create_sha512_hash(file_info.actual_full_pathname))
+
+
+def _sort_files(files):
+    def _lenfunc(obj):
+        return len(obj.full_pathname_splitted)
+
+    def _keyfunc(file, i):
+        return file.full_pathname_splitted[i - 1]
+
+    longest_path_length = len(max(files, key=_lenfunc).full_pathname_splitted) - 1
+
+    for file_info in files:
+        del file_info.full_pathname_splitted[-1]
+
+        path_length = len(file_info.full_pathname_splitted)
+        file_info.full_pathname_splitted.extend([''] * (longest_path_length - path_length))
+
+    for path_length in range(longest_path_length, 0, -1):
+        files.sort(key=lambda f, i=path_length: _keyfunc(f, i))
+    return files
+
+
+def create_flat_content_tag(root_element, package_info, hash_algorithms):
+    last_full_pathname = ""
+    last_directory_tag = ""
+
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
+    if len(package_info.files) > 0:
+        package_info.files = _sort_files(package_info.files)
+
+    for file_info in package_info.files:
+
+        head, file_name = ntpath.split(file_info.full_pathname)
+        root, folder_name = ntpath.split(head)
+        if root == '//':
+            root = '/'
+
+        full_pathname = root + folder_name
+
+        if last_full_pathname == full_pathname:
+            file_tag = ET.SubElement(last_directory_tag, 'File')
+            file_tag.set('name', file_name)
+        else:
+            directory_tag = ET.SubElement(root_element, 'Directory')
+            directory_tag.set('root', root)
+            directory_tag.set('name', folder_name)
+            file_tag = ET.SubElement(directory_tag, 'File')
+            file_tag.set('name', file_name)
+            last_full_pathname = full_pathname
+            last_directory_tag = directory_tag
+
+        if file_info.mutable:
+            file_tag.set('n8060:mutable', "true")
+
+        file_tag.set('size', file_info.size)
+
+        _add_hashes(file_info, file_tag, hash_algorithms)
+
+    return root_element
+
+
+def create_hierarchic_content_tag(root_element, package_info, hash_algorithms):
+    root_element.set('n8060:pathSeparator', '/')
+    root_element.set('n8060:envVarPrefix', '$')
+    root_element.set('n8060:envVarSuffix', '')
+
+    def _file_hierarchy(filelist, depth=0, parent_tag=None):
+        def _keyfunc(obj):
+            return obj.full_pathname_splitted[depth]
+
+        filelist.sort(key=_keyfunc)
+
+        for head, tail_of_file_iterator in groupby(filelist, _keyfunc):
+            sub_files = list()
+            for file_info in tail_of_file_iterator:
+                if depth + 1 >= len(file_info.full_pathname_splitted):
+                    file_tag = ET.SubElement(parent_tag, 'File')
+                    file_tag.set('name', file_info.name)
+                    if file_info.mutable:
+                        file_tag.set('n8060:mutable', "true")
+                    file_tag.set('size', file_info.size)
+                    if depth == 0:
+                        if os.path.isabs(file_info.full_pathname):
+                            file_tag.set('root', '/')
+
+                    _add_hashes(file_info, file_tag, hash_algorithms)
+                else:
+                    sub_files.append(file_info)
+
+            if len(sub_files) > 0:
+                sub_tag = ET.SubElement(parent_tag, 'Directory')
+                sub_tag.set('name', head)
+                if depth == 0:
+                    if os.path.isabs(file_info.full_pathname):
+                        sub_tag.set('root', '/')
+                _file_hierarchy(sub_files, depth=depth + 1, parent_tag=sub_tag)
+
+    _file_hierarchy(list(package_info.files), parent_tag=root_element)
+
+    return root_element

--- a/tag_generator/generators/softwareid_generator.py
+++ b/tag_generator/generators/softwareid_generator.py
@@ -1,0 +1,16 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from .utils import create_unique_id, create_software_id
+
+
+def create_software_ids(env, regid, id_prefix=None, dpkg_include_package_arch=False):
+    pkg_info = env.get_package_list({'dpkg_include_package_arch': dpkg_include_package_arch})
+    os_string = env.get_os_string()
+    architecture = env.get_architecture()
+
+    for pi in pkg_info:
+        unique_id = create_unique_id(pi, os_string, architecture, id_prefix)
+        software_id = create_software_id(regid, unique_id)
+        yield software_id

--- a/tag_generator/generators/swid_generator.py
+++ b/tag_generator/generators/swid_generator.py
@@ -1,0 +1,253 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+from xml.etree import ElementTree as ET
+from signature_template import SIGNATURE
+from package_info import PackageInfo
+from utils import create_unique_id, create_software_id, create_system_id
+from content_creator import create_flat_content_tag, create_hierarchic_content_tag
+import re
+
+ROLE = 'tagCreator'
+VERSION_SCHEME = 'alphanumeric'
+XMLNS = 'http://standards.iso.org/iso/19770/-2/2015/schema.xsd'
+XML_DECLARATION = '<?xml version="1.0" encoding="utf-8"?>'
+N8060 = 'http://csrc.nist.gov/ns/swid/2015-extensions/1.0'
+XSI = 'http://www.w3.org/2001/XMLSchema-instance'
+SCHEMA_LOCATION = XMLNS + ' http://standards.iso.org/iso/19770/-2/2015-current/schema.xsd ' \
+    + N8060 + ' https://csrc.nist.gov/schema/swid/2015-extensions/swid-2015-extensions-1.0.xsd'
+SHA256NS = 'http://www.w3.org/2001/04/xmlenc#sha256'
+SHA384NS = 'http://www.w3.org/2001/04/xmldsig-more#sha384'
+SHA512NS = 'http://www.w3.org/2001/04/xmlenc#sha512'
+
+
+def _create_flat_payload_tag(package_info, hash_algorithms):
+    payload = ET.Element('Payload')
+    return create_flat_content_tag(payload, package_info, hash_algorithms)
+
+
+def _create_flat_evidence_tag(package_info, hash_algorithms):
+    evidence = ET.Element('Evidence')
+    return create_flat_content_tag(evidence, package_info, hash_algorithms)
+
+
+def _create_hierarchic_payload_tag(package_info, hash_algorithms):
+    payload = ET.Element('Payload')
+    return create_hierarchic_content_tag(payload, package_info, hash_algorithms)
+
+
+def _create_hierarchic_evidence_tag(package_info, hash_algorithms):
+    evidence = ET.Element('Evidence')
+    return create_hierarchic_content_tag(evidence, package_info, hash_algorithms)
+
+
+def all_matcher(ctx):
+    return True
+
+
+def package_name_matcher(ctx, value):
+    return ctx['package_info'].package == value
+
+
+def software_id_matcher(ctx, value):
+    unique_id = create_unique_id(ctx['package_info'], ctx['os_string'], ctx['architecture'], ctx['id_prefix'])
+    software_id = create_software_id(ctx['regid'], unique_id)
+    return software_id == value
+
+
+def create_software_identity_element(ctx, from_package_file=False, from_folder=False):
+    """
+    This method creates the SoftwareIdentity-Tag for the SWID.
+    :param from_folder: Root-Folder for the Evidence-Tag.
+    :param ctx: Information of package and arguments given by User (example: full-flag, regid, etc.)
+    :param from_package_file: Flag if the File-List comes from a Package-File or a local installed Package.
+    :return: Whole Identification-Tag with all Information given.
+    """
+    software_identity = ET.Element('SoftwareIdentity')
+    software_identity.set('xmlns', XMLNS)
+    software_identity.set('xmlns:n8060', N8060)
+    if ctx['schema_location']:
+        software_identity.set('xmlns:xsi', XSI)
+        software_identity.set('xsi:schemaLocation', SCHEMA_LOCATION)
+    software_identity.set('name', ctx['package_info'].package)
+    software_identity.set('xml:lang', ctx['xml_lang'])
+    software_identity.set('tagId', create_unique_id(ctx['package_info'], ctx['os_string'], ctx['architecture'], ctx['id_prefix']))
+    software_identity.set('version', ctx['package_info'].version)
+    software_identity.set('versionScheme', VERSION_SCHEME)
+
+    entity = ET.SubElement(software_identity, 'Entity')
+    entity.set('name', ctx['entity_name'])
+    entity.set('regid', ctx['regid'])
+    entity.set('role', ROLE)
+
+    product_meta = ET.SubElement(software_identity, 'Meta')
+    if ctx['meta_for'] == 'os':
+        product_meta.set('product', create_system_id(ctx['os_string'], ctx['architecture']))
+    else:
+        product_meta.set('product', ctx['package_info'].package)
+        colloquialVersion = re.sub(r'-.+$', '', ctx['package_info'].version)
+        product_meta.set('colloquialVersion', colloquialVersion)
+        if ctx['package_info'].summary:
+            product_meta.set('summary', ctx['package_info'].summary)
+
+    if ctx['full']:
+
+        if 'sha256' in ctx['hash_algorithms']:
+            software_identity.set('xmlns:SHA256', SHA256NS)
+        if 'sha384' in ctx['hash_algorithms']:
+            software_identity.set('xmlns:SHA384', SHA384NS)
+        if 'sha512' in ctx['hash_algorithms']:
+            software_identity.set('xmlns:SHA512', SHA512NS)
+
+        if from_package_file:
+            ctx['package_info'].files.extend(ctx['environment'].get_files_from_packagefile(ctx['file_path']))
+        elif from_folder:
+            for folder in ctx['evidence_paths']:
+                ctx['package_info'].files.extend(ctx['environment'].get_files_from_folder(folder, ctx['new_root_path']))
+            ctx['package_info'].files.sort(key=lambda file: file.actual_full_pathname)
+        else:
+            ctx['package_info'].files.extend(ctx['environment'].get_files_for_package(ctx['package_info']))
+
+        if ctx['hierarchic']:
+            if from_folder:
+                content_tag = _create_hierarchic_evidence_tag(ctx['package_info'], ctx['hash_algorithms'])
+            else:
+                content_tag = _create_hierarchic_payload_tag(ctx['package_info'], ctx['hash_algorithms'])
+        else:
+            if from_folder:
+                content_tag = _create_flat_evidence_tag(ctx['package_info'], ctx['hash_algorithms'])
+            else:
+                content_tag = _create_flat_payload_tag(ctx['package_info'], ctx['hash_algorithms'])
+
+        software_identity.append(content_tag)
+
+    return software_identity
+
+
+def create_swid_tags(environment, entity_name, regid, os_string=None, architecture=None, hash_algorithms='sha256',
+                     full=False, matcher=all_matcher, hierarchic=False, file_path=None, evidence_paths=None,
+                     name=None, version=None, new_root_path=None, pkcs12_file=None, xml_lang=None, schema_location=False,
+                     meta_for='os', id_prefix=None, dpkg_include_package_arch=False):
+    """
+    Return SWID tags as utf8-encoded xml bytestrings for all available
+    packages.
+
+    :param pkcs12_file: Path to the pkcs12 file.
+    :param new_root_path: Evidence SWID tag Root path.
+    :param version: Evidence SWID tag version.
+    :param name: Evidence SWID tag name.
+    :param meta_for: Whether the Meta element should hold information about the distribution or about the package.
+    :param evidence_paths: List of folders from which the evidence method starts to create SWID tag.
+    :param file_path: File-Path to the Package-File.
+    :param hierarchic: Optional parameter for the creation of a hierarchical SWID tag.
+    :param environment: The package management environment.
+    :param entity_name: The SWID tag entity name.
+    :param id_prefix: Custom prefix for unique IDs.
+    :param regid: The SWID tag regid.
+    :param hash_algorithms: Comma separated list of the hash algorithms to include in the SWID tag,
+    :param full: Whether to include file payload. Default is False.
+    :param matcher: A function that defines whether to return a tag or not. Default is a function that returns ``True`` for all tags.
+    :param xml_lang: xml:lang attribute value. Default en-US.
+    :param dpkg_include_package_arch: Whether to include architecture in tagId and version.
+
+    Returns:
+        A generator object for all available SWID XML strings. The XML strings
+        are all bytestrings, using UTF-8 encoding.
+
+    """
+
+    ctx = {
+        'regid': regid,
+        'environment': environment,
+        'entity_name': entity_name,
+        'os_string': os_string,
+        'architecture': architecture,
+        'meta_for': meta_for,
+        'full': full,
+        'hash_algorithms': hash_algorithms,
+        'hierarchic': hierarchic,
+        'file_path': file_path,
+        'evidence_paths': evidence_paths,
+        'new_root_path': new_root_path,
+        'xml_lang': xml_lang,
+        'schema_location': schema_location,
+        'id_prefix': id_prefix,
+        'dpkg_include_package_arch': dpkg_include_package_arch,
+    }
+
+    if os_string is None:
+        ctx['os_string'] = ctx['environment'].get_os_string()
+
+    if architecture is None:
+        ctx['architecture'] = ctx['environment'].get_architecture()
+
+    if file_path is not None:
+        pi = environment.get_packageinfo_from_packagefile(file_path, ctx)
+
+        ctx['package_info'] = pi
+
+        software_identity = create_software_identity_element(ctx, from_package_file=True)
+
+        if pkcs12_file is not None:
+            ET.register_namespace('dsig', "http://www.w3.org/2000/09/xmldsig#")
+            signature_template_tree = ET.fromstring(SIGNATURE)
+            software_identity.append(signature_template_tree)
+
+        swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+        yield XML_DECLARATION.encode('utf-8') + swidtag
+
+    elif evidence_paths is not None and len(evidence_paths) > 0:
+        pi = PackageInfo()
+        pi.package = name
+        pi.version = version
+
+        ctx['package_info'] = pi
+
+        software_identity = create_software_identity_element(ctx, from_folder=True)
+
+        if pkcs12_file is not None:
+            ET.register_namespace('dsig', "http://www.w3.org/2000/09/xmldsig#")
+            signature_template_tree = ET.fromstring(SIGNATURE)
+            software_identity.append(signature_template_tree)
+
+        swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+        yield XML_DECLARATION.encode('utf-8') + swidtag
+
+    elif name is not None and version is not None:
+        pi = PackageInfo()
+        pi.package = name
+        pi.version = version
+
+        ctx['package_info'] = pi
+        ctx['full'] = False
+
+        software_identity = create_software_identity_element(ctx)
+
+        if pkcs12_file is not None:
+            ET.register_namespace('dsig', "http://www.w3.org/2000/09/xmldsig#")
+            signature_template_tree = ET.fromstring(SIGNATURE)
+            software_identity.append(signature_template_tree)
+
+        swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+        yield XML_DECLARATION.encode('utf-8') + swidtag
+
+    else:
+        pkg_info = environment.get_package_list(ctx)
+
+        for pi in pkg_info:
+
+            ctx['package_info'] = pi
+
+            # Check if the software-id of the current package matches the targeted request
+            if not matcher(ctx):
+                continue
+            software_identity = create_software_identity_element(ctx)
+
+            if pkcs12_file is not None:
+                ET.register_namespace('dsig', "http://www.w3.org/2000/09/xmldsig#")
+                signature_template_tree = ET.fromstring(SIGNATURE)
+                software_identity.append(signature_template_tree)
+
+            swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+            yield XML_DECLARATION.encode('utf-8') + swidtag

--- a/tag_generator/generators/utils.py
+++ b/tag_generator/generators/utils.py
@@ -1,0 +1,131 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import hashlib
+import os
+import re
+import random
+import string
+
+
+uri_reserved_chars_re = re.compile(r'[:\/?#\[\]@!$&\'()*+,;=]')
+
+
+def create_unique_id(package_info, os_string, architecture, id_prefix):
+    """
+    Create a Unique-ID.
+
+    Args:
+        package_info (PackageInfo):
+            A ``PackageInfo`` instance.
+        os_string (str):
+            An string representing the current distribution,
+            e.g. ``Debian_7.4`` or ``Fedora_19``.
+        architecture (str):
+            The system architecture, e.g. ``x86_64`` or ``i386``.
+
+    Returns:
+        The Unique-ID string.
+
+    """
+    if id_prefix is None:
+        unique_id_format = '{os_string}-{architecture}-{pi.package}-{pi.version}'
+    else:
+        unique_id_format = '{id_prefix}{pi.package}-{pi.version}'
+    unique_id = unique_id_format.format(os_string=os_string,
+                                        architecture=architecture,
+                                        pi=package_info,
+                                        id_prefix=id_prefix)
+    return uri_reserved_chars_re.sub('~', unique_id)
+
+
+def create_system_id(os_string, architecture):
+    """
+    Create a system-ID by joining the OS-String and the architecture with a hyphen.
+
+    Args:
+        os_string (str):
+            The Operating system string.
+        architecture (str):
+            The Architecture string.
+
+    Returns:
+        The System-ID string.
+
+    """
+    system_id_format = '{os_string} {architecture}'
+    return system_id_format.format(os_string=os_string.replace('_', ' '),
+                                   architecture=architecture)
+
+
+def create_software_id(regid, unique_id):
+    """
+    Create a Software-ID by joining the Regid and the Unique-ID with a double underscore.
+
+    Args:
+        regid (str):
+            The Regid string.
+        unique_id (str):
+            The Unique-ID string.
+
+    Returns:
+        The Software-ID string.
+
+    """
+    return '{regid}__{unique_id}'.format(regid=regid, unique_id=unique_id)
+
+
+def create_sha256_hash(filepath):
+    return _create_hash(filepath, hashlib.sha256())
+
+
+def create_sha384_hash(filepath):
+    return _create_hash(filepath, hashlib.sha384())
+
+
+def create_sha512_hash(filepath):
+    return _create_hash(filepath, hashlib.sha512())
+
+
+def _create_hash(file_path, hash_algorithm):
+    blocksize = 65536
+    with open(file_path, 'rb') as afile:
+        buf = afile.read(blocksize)
+        while len(buf) > 0:
+            hash_algorithm.update(buf)
+            buf = afile.read(blocksize)
+
+    return hash_algorithm.hexdigest()
+
+
+def create_temp_folder(file_path):
+    """
+    It creates a folder in the directory /tmp of the client/server.
+    This folder has the prefix "swid_". To this prefix a random generated String is appended to
+    prevent collisions of foldernames.
+
+    :param file_path: Path to the file (package or certificate)
+    :return: A dictionary with the save options of the temporary folder.
+    """
+    temp_folder_name = '/tmp'
+    folder_prefix = 'swid_'
+
+    random_string = ''.join(random.choice(string.ascii_letters) for _ in range(5))
+
+    if file_path[0] == "/":
+        absolute_package_path = file_path
+    else:
+        absolute_package_path = '/'.join((os.getcwd(), file_path))
+
+    save_location_pathname = '/'.join((temp_folder_name, folder_prefix + random_string))
+
+    if not os.path.exists(save_location_pathname):
+        os.makedirs(save_location_pathname)
+
+    folder_information = {
+        'absolute_package_path': absolute_package_path,
+        'save_location': save_location_pathname
+    }
+
+    return folder_information

--- a/tag_generator/main.py
+++ b/tag_generator/main.py
@@ -1,0 +1,34 @@
+# This script prints a simple swid tag. It requires two command-line arguments.
+# The first command-line argument is the name of the software.
+# The second command-line argument is the version of the software.
+
+# Tag Generating code partially sourced from https://github.com/strongswan/swidGenerator
+
+# Import neccessary functions, many from strongswan's swidGenerator
+from generators.swid_generator import create_software_identity_element
+from package_info import PackageInfo
+from xml.etree import ElementTree as ET
+import sys, platform
+
+# Initialize the XML string to be used in swid tag
+XML_DECLARATION = '<?xml version="1.0" encoding="utf-8"?>'
+
+# Generate swid tag based on command-line arguments and environment
+software_identity = create_software_identity_element(
+    {
+        "schema_location": False,
+        "package_info": PackageInfo(sys.argv[1], version = sys.argv[2]),
+        "xml_lang": "en-US",
+        "os_string": platform.linux_distribution()[0] + " " + platform.linux_distribution()[1],
+        "architecture": platform.machine(),
+        "id_prefix": platform.linux_distribution()[0] + "_" + platform.linux_distribution()[1] \
+        + '-' + platform.machine() + '-',
+        "entity_name": "blossom-sam",
+        "regid": "blossom-sam.com",
+        "meta_for": "os",
+        "full": False
+    })
+
+# Generate utf8-encoded xml bytestring and print
+swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+print(XML_DECLARATION.encode('utf-8') + swidtag)

--- a/tag_generator/package_info.py
+++ b/tag_generator/package_info.py
@@ -1,0 +1,37 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import os.path
+
+
+class FileInfo(object):
+    def __init__(self, path, actual_path=True):
+        self.name = (os.path.split(path)[1]).strip()
+        self.location = (os.path.split(path)[0]).strip()
+        self.mutable = False
+        self.full_pathname = '/'.join((self.location, self.name))
+
+        splitted_location = self.full_pathname.split('/')
+        self.full_pathname_splitted = splitted_location[1:]
+
+        if actual_path:
+            self.actual_full_pathname = self.full_pathname
+            self.size = str(os.path.getsize(self.full_pathname))
+        else:
+            self.actual_full_pathname = ""
+
+    def set_actual_path(self, file_path):
+        self.actual_full_pathname = file_path.encode('utf-8')
+        self.size = str(os.path.getsize(file_path))
+
+
+class PackageInfo(object):
+    def __init__(self, package='', version='', files=None, status=None, summary=None):
+        if files is None:
+            files = []
+        self.package = package
+        self.version = version
+        self.files = files
+        self.status = status
+        self.summary = summary

--- a/tag_generator/patches.py
+++ b/tag_generator/patches.py
@@ -1,0 +1,46 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import subprocess
+import inspect
+
+
+def py26_check_output(*popenargs, **kwargs):
+    """
+    This function is an ugly hack to monkey patch the backported `check_output`
+    method into the subprocess module.
+
+    Taken from https://gist.github.com/edufelipe/1027906.
+
+    """
+    process = subprocess.Popen(stdout=subprocess.PIPE, *popenargs, **kwargs)
+    output, _ = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        cmd = kwargs.get('args')
+        if cmd is None:
+            cmd = popenargs[0]
+        error = subprocess.CalledProcessError(retcode, cmd)
+        error.output = output
+        raise error
+    return output
+
+
+def unicode_patch(string):
+    """
+    This is a ugly unicode-patch. Problem is decoding of special characters in packages.
+    E.g: TÜRKTRUST_Elektronik_Sertifika_Hizmet_Sağlayıcısı_H5.crt
+
+    In Python 2.7 Unicode-Class to translate string in unicode-format exists. In Python-Versions 3+,
+    this class do not exists anymore. Alternative str()-Constructor is used.
+
+    :param string: String to decode.
+    :return: Decoded string in UTF-8.
+    """
+    try:
+        inspect.getmembers(unicode)
+        string_in_bytes = bytes(string)
+        return string_in_bytes.decode('utf-8')
+    except NameError:
+        return string

--- a/tag_generator/signature_template.py
+++ b/tag_generator/signature_template.py
@@ -1,0 +1,18 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+SIGNATURE = '<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">' \
+            '<SignedInfo>' \
+            '<CanonicalizationMethod Algorithm="http://www.w3.org/2006/12/xml-c14n11"/>' \
+            '<SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>' \
+            '<Reference>' \
+            '<Transforms>' \
+            '<Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>' \
+            '<Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>' \
+            '</Transforms>' \
+            '<DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>' \
+            '<DigestValue />' \
+            '</Reference>' \
+            '</SignedInfo>' \
+            '<SignatureValue />' \
+            '<KeyInfo><X509Data />' \
+            '</KeyInfo>' \
+            '</Signature>'

--- a/tag_generator/utils.py
+++ b/tag_generator/utils.py
@@ -1,0 +1,131 @@
+# Code modified from https://github.com/strongswan/swidGenerator
+# -*- coding: utf-8 -*-
+from __future__ import print_function, division, absolute_import, unicode_literals
+
+import hashlib
+import os
+import re
+import random
+import string
+
+
+uri_reserved_chars_re = re.compile(r'[:\/?#\[\]@!$&\'()*+,;=]')
+
+
+def create_unique_id(package_info, os_string, architecture, id_prefix):
+    """
+    Create a Unique-ID.
+
+    Args:
+        package_info (PackageInfo):
+            A ``PackageInfo`` instance.
+        os_string (str):
+            An string representing the current distribution,
+            e.g. ``Debian_7.4`` or ``Fedora_19``.
+        architecture (str):
+            The system architecture, e.g. ``x86_64`` or ``i386``.
+
+    Returns:
+        The Unique-ID string.
+
+    """
+    if id_prefix is None:
+        unique_id_format = '{os_string}-{architecture}-{pi.package}-{pi.version}'
+    else:
+        unique_id_format = '{id_prefix}{pi.package}-{pi.version}'
+    unique_id = unique_id_format.format(os_string=os_string,
+                                        architecture=architecture,
+                                        pi=package_info,
+                                        id_prefix=id_prefix)
+    return uri_reserved_chars_re.sub('~', unique_id)
+
+
+def create_system_id(os_string, architecture):
+    """
+    Create a system-ID by joining the OS-String and the architecture with a hyphen.
+
+    Args:
+        os_string (str):
+            The Operating system string.
+        architecture (str):
+            The Architecture string.
+
+    Returns:
+        The System-ID string.
+
+    """
+    system_id_format = '{os_string} {architecture}'
+    return system_id_format.format(os_string=os_string.replace('_', ' '),
+                                   architecture=architecture)
+
+
+def create_software_id(regid, unique_id):
+    """
+    Create a Software-ID by joining the Regid and the Unique-ID with a double underscore.
+
+    Args:
+        regid (str):
+            The Regid string.
+        unique_id (str):
+            The Unique-ID string.
+
+    Returns:
+        The Software-ID string.
+
+    """
+    return '{regid}__{unique_id}'.format(regid=regid, unique_id=unique_id)
+
+
+def create_sha256_hash(filepath):
+    return _create_hash(filepath, hashlib.sha256())
+
+
+def create_sha384_hash(filepath):
+    return _create_hash(filepath, hashlib.sha384())
+
+
+def create_sha512_hash(filepath):
+    return _create_hash(filepath, hashlib.sha512())
+
+
+def _create_hash(file_path, hash_algorithm):
+    blocksize = 65536
+    with open(file_path, 'rb') as afile:
+        buf = afile.read(blocksize)
+        while len(buf) > 0:
+            hash_algorithm.update(buf)
+            buf = afile.read(blocksize)
+
+    return hash_algorithm.hexdigest()
+
+
+def create_temp_folder(file_path):
+    """
+    It creates a folder in the directory /tmp of the client/server.
+    This folder has the prefix "swid_". To this prefix a random generated String is appended to
+    prevent collisions of foldernames.
+
+    :param file_path: Path to the file (package or certificate)
+    :return: A dictionary with the save options of the temporary folder.
+    """
+    temp_folder_name = '/tmp'
+    folder_prefix = 'swid_'
+
+    random_string = ''.join(random.choice(string.ascii_letters) for _ in range(5))
+
+    if file_path[0] == "/":
+        absolute_package_path = file_path
+    else:
+        absolute_package_path = '/'.join((os.getcwd(), file_path))
+
+    save_location_pathname = '/'.join((temp_folder_name, folder_prefix + random_string))
+
+    if not os.path.exists(save_location_pathname):
+        os.makedirs(save_location_pathname)
+
+    folder_information = {
+        'absolute_package_path': absolute_package_path,
+        'save_location': save_location_pathname
+    }
+
+    return folder_information

--- a/tag_generator/yaml_parse.py
+++ b/tag_generator/yaml_parse.py
@@ -8,10 +8,10 @@ from package_info import PackageInfo
 from xml.etree import ElementTree as ET
 import yaml
 
-#
+# Open the manifest yaml fike
 stream = open('manifest.yaml', 'r')
 
-#
+# Extract the manifest from the yaml file
 manifest = yaml.load(stream)['manifest']
     
 # Initialize the XML string to be used in swid tag
@@ -33,6 +33,14 @@ software_identity = create_software_identity_element(
         "full": False
     })
 
+# If a publisher is listed in the manifest file, add it to the tag
+if 'publisher' in manifest:
+    entity = ET.SubElement(software_identity, 'Entity')
+    entity.set('name', manifest['publisher'])
+    entity.set('regid', manifest['publisher'] + '.org')
+    entity.set('role', 'softwareCreator')
+
 # Generate utf8-encoded xml bytestring and print
 swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+print(type(software_identity))
 print(XML_DECLARATION.encode('utf-8') + swidtag)

--- a/tag_generator/yaml_parse.py
+++ b/tag_generator/yaml_parse.py
@@ -1,0 +1,38 @@
+# This script prints a simple swid tag from a yaml file
+
+# Tag Generating code partially sourced from https://github.com/strongswan/swidGenerator
+
+# Import neccessary functions, many from strongswan's swidGenerator
+from generators.swid_generator import create_software_identity_element
+from package_info import PackageInfo
+from xml.etree import ElementTree as ET
+import yaml
+
+#
+stream = open('manifest.yaml', 'r')
+
+#
+manifest = yaml.load(stream)['manifest']
+    
+# Initialize the XML string to be used in swid tag
+XML_DECLARATION = '<?xml version="1.0" encoding="utf-8"?>'
+
+# Generate swid tag based on command-line arguments and environment
+software_identity = create_software_identity_element(
+    {
+        "schema_location": False,
+        "package_info": PackageInfo(manifest['software'], version = str(manifest['version'])),
+        "xml_lang": manifest['language'],
+        "os_string": manifest['os']['distro'] + " " + str(manifest['os']['version']),
+        "architecture": manifest['architecture'],
+        "id_prefix": manifest['os']['distro'] + "_" + str(manifest['os']['version']) \
+        + '-' + manifest['architecture'] + '-',
+        "entity_name": "blossom-sam",
+        "regid": "blossom-sam.com",
+        "meta_for": "os",
+        "full": False
+    })
+
+# Generate utf8-encoded xml bytestring and print
+swidtag = ET.tostring(software_identity, encoding='utf-8').replace(b'\n', b'')
+print(XML_DECLARATION.encode('utf-8') + swidtag)


### PR DESCRIPTION
This PR adds relevant code from https://github.com/strongswan/swidGenerator for generating swid-tags. This PR also adds scripts for generating swid-tags from command line arguments and from yaml files. This closes #1, depends on merging the `develop-demoapps` branch.

The following files are modified files from https://github.com/strongswan/swidGenerator:
- tag_generator/command_manager.py
- tag_generator/content_creator.py
- tag_generator/exceptions.py
- tag_generator/generators/__init__.py
- tag_generator/generators/content_creator.py
- tag_generator/generators/softwareid_generator.py
- tag_generator/generators/swid_generator.py
- tag_generator/generators/utils.py
- tag_generator/package_info.py
- tag_generator/patches.py
- tag_generator/signature_template.py
- tag_generator/utils.py

The `tag_generator/main.py` script is used to generate a swid tag from command line arguments e.g. `python3 main.py 'Hello Washington' 1.0.0`

The `tag_generator/yaml_parse.py` script is used to generate a swid tag from a `manifest.yaml` file e.g. `python3 yaml_parse` with the `manifest.yaml` file in the same directory.